### PR TITLE
Close socket after sending WOL

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,7 @@ exports.wake = function(macAddress, options, callback) {
     if(!error) {
       callback();
     }
+    socket.close();
   });
   
   socket.on('error', function(error) {


### PR DESCRIPTION
Previously, socket would not be closed after sending WOLs. Repeatedly calling `wake()` would at some point result in too many file descriptors being open. 

Under Linux, you can check how many sockets `node` keeps open with: 
```
lsof -i -n -P  | grep node
```